### PR TITLE
Clearlinux travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:16.04
+FROM clearlinux:base
 
 MAINTAINER shrmrf "https://github.com/shrmrf"
 
 # Install packages for building acrn
-RUN apt-get update
-RUN apt-get install -y  build-essential wget git
+# RUN swupd update
+RUN swupd bundle-add  os-core-dev
 
 RUN apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER shrmrf "https://github.com/shrmrf"
 # RUN swupd update
 RUN swupd bundle-add  os-core-dev
 
-RUN apt-get clean
+RUN git config --global http.sslVerify false
 
 RUN git clone https://github.com/shrmrf/acrn-hypervisor /root/acrn-hypervisor
 RUN cd /root/acrn-hypervisor; make clean && make all

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN swupd bundle-add  os-core-dev
 
 RUN git config --global http.sslVerify false
 
-RUN git clone https://github.com/shrmrf/acrn-hypervisor /root/acrn-hypervisor
+COPY  . /root/acrn-hypervisor
 RUN cd /root/acrn-hypervisor; make clean && make all


### PR DESCRIPTION
Update `Dockerfile` to `COPY` instead of running `git clone`. Creates independence from passing environment variables etc. Simple!